### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/0b1da8c2-8ec2-4360-b4c1-398072a50dd6/5d6b936a-55d2-4043-a36c-961d83b50a9d/_apis/work/boardbadge/b367a131-dcd6-4191-8fc8-be0da76daff0)](https://dev.azure.com/aiw-devops/0b1da8c2-8ec2-4360-b4c1-398072a50dd6/_boards/board/t/5d6b936a-55d2-4043-a36c-961d83b50a9d/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#290](https://dev.azure.com/aiw-devops/0b1da8c2-8ec2-4360-b4c1-398072a50dd6/_workitems/edit/290). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.